### PR TITLE
docs: enable auto-merge by default for all PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@
 * Provide suggestions for refactoring, simplification, or modernization. Unless otherwise directed, this should always
   be initiated through a new feature/folder and spec.md file.
 
+# Pull Requests
+
+* Always enable auto-merge (`gh pr merge --auto --squash`) immediately after creating a PR.
+
 # General Instructions
 
 * You will be told if the conversation is either planning or implementation. If not told, ask.


### PR DESCRIPTION
## Summary

- Adds a Pull Requests section to CLAUDE.md instructing Claude to always run `gh pr merge --auto --squash` immediately after creating a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)