### PR TITLE
docs: ci-cd pipeline spec and ADR (#37)

### DIFF
--- a/features/37 - ci-cd pipeline/adr.md
+++ b/features/37 - ci-cd pipeline/adr.md
@@ -1,0 +1,163 @@
+# ADR: CI/CD Pipeline Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+The existing CI/CD setup is partially automated:
+- GitHub Actions runs lint and build checks on PRs and pushes to `main`
+- Cloud Build is triggered manually via semantic version release tags to build, push, and deploy to Cloud Run
+- No automated tests exist beyond the build step (backend tests are skipped; frontend tests are not run in CI)
+- There is no test environment — builds deploy directly to production
+- There is no automatic rollback on failure
+- Deployment requires a developer to manually create and push a release tag
+
+The goal is a fully automated pipeline where a merge to `main` is the only human action required to deliver a
+verified, deployed release to production.
+
+## Decisions
+
+### 1. Remove manual release tags — trigger Cloud Build on every merge to `main`
+
+**Decision:** Cloud Build is triggered automatically on every push to `main`. No release tags are required.
+
+**Why:** Release tags require a manual step, which breaks the "no manual steps" requirement. Every merge to `main`
+should represent a potentially shippable release; manual tagging introduces a gap between "merged" and "released"
+that adds friction without adding value.
+
+### 2. Kebab-case CalVer + short SHA for image versioning
+
+**Decision:** Docker images and Cloud Run revisions are tagged as `YYYY-MM-DD-{short-sha}` (e.g. `2026-03-15-a3f2c91`).
+
+**Why:** Semantic versioning (MAJOR.MINOR.PATCH) requires human judgement to assign version numbers, which is
+incompatible with fully automated releases. CalVer + SHA provides:
+- Human-readable date context at a glance
+- Unique, collision-free identifiers from git
+- Full traceability from image tag back to the exact commit
+- No manual input required
+
+### 3. Hybrid GitHub Actions + Cloud Build pipeline
+
+**Decision:** Unit tests and linting run in GitHub Actions as a PR gate. Integration and E2E tests run in Cloud Build
+after merge.
+
+**Why:** Integration and E2E tests require access to GCP services (GCS, Cloud Run). Running them in GitHub Actions
+introduces authentication complexity, network latency variance to GCP services, and potential flakiness for
+WebSocket stability and large file upload tests. Cloud Build runs within GCP's network and authenticates natively via
+service accounts. GitHub Actions is retained for unit tests because it provides the fastest possible PR gate feedback
+with no GCP dependency.
+
+### 4. Testcontainers for integration test database
+
+**Decision:** Integration tests use Testcontainers to spin up an ephemeral PostgreSQL instance per test run. No
+persistent test Cloud SQL instance.
+
+**Why:**
+- A persistent test database accumulates state across runs; a failed test mid-run can leave the DB in a broken state
+  that causes subsequent tests in that run to fail for unrelated reasons
+- Testcontainers gives each run a clean schema created by Hibernate from Java entity definitions, seeded only with
+  what the tests explicitly insert
+- Spring Boot 3.1+ `@ServiceConnection` integrates Testcontainers with zero boilerplate
+- Eliminates ongoing Cloud SQL cost for a test instance
+
+### 5. Hibernate `ddl-auto=create-drop` — no migration tooling
+
+**Decision:** The `test` Spring profile uses `ddl-auto=create-drop`. No Flyway or Liquibase.
+
+**Why:** Hibernate already manages the production schema via `ddl-auto=update`, inferring all table/column
+definitions from Java entity classes. This was a deliberate architectural choice: schema changes are expressed in
+Java, not SQL. Adding a migration tool for test would introduce a parallel schema representation that must be kept
+in sync with the entity classes — unnecessary overhead.
+
+For `create-drop` in tests: Hibernate creates the full schema on container startup and drops it on shutdown. The
+Testcontainers container is destroyed after each run regardless, so the drop is redundant but harmless. If Hibernate's
+drop ordering produces foreign key constraint errors on first run, the fix is adjusting entity relationship
+annotations — not adding a migration tool.
+
+**Flyway deferred:** If a future schema change requires a destructive migration (rename/drop a column with existing
+production data), a Flyway script for that one-off operation is appropriate. That decision belongs in a separate
+ticket scoped to that migration. It has no bearing on this pipeline.
+
+### 6. Playwright for E2E and WebSocket multi-user testing
+
+**Decision:** Playwright is used for all E2E tests, including multi-user WebSocket simulation via multiple browser
+contexts in a single test process.
+
+**Why:**
+- Playwright has native WebSocket support and can intercept, assert on, and wait for WS frames
+- Multiple browser contexts in one Playwright process share the same test runner, allowing synchronized multi-user
+  scenarios (e.g., User A edits, assert User B sees the change) without external coordination
+- Playwright runs headless in Cloud Build without additional configuration
+- TypeScript-native, consistent with the frontend codebase
+- Configurable user count (`WS_USER_COUNT`, default `3`) allows the same test suite to be run with more users
+  ad-hoc without duplicating test logic
+
+**On user count (3 vs upper limit):** 3 concurrent users covers all meaningful state transitions: concurrent
+read/write to the same cell, watch-only observation, and three-way presence tracking. Running at the upper limit
+(10) in CI would increase runtime and introduce flakiness without catching a meaningfully different class of bugs.
+Load and stress testing beyond 3 users is done ad-hoc, outside the CI gate.
+
+**Alternatives considered:**
+- **Cypress** — does not support multiple origins or multiple simultaneous sessions in one test easily; WebSocket
+  support is indirect. Rejected.
+- **Custom Node.js scripts with `@stomp/stompjs`** — can simulate concurrent WebSocket connections but cannot test
+  browser rendering or UI state. Suitable for standalone load testing; not a replacement for E2E.
+
+### 7. Mock Google OAuth in integration tests
+
+**Decision:** Google OAuth token exchange is mocked in integration tests. A manual OAuth check is performed after
+each successful production deployment.
+
+**Why:** Testing the full OAuth exchange in CI requires real Google credentials, token refresh logic, and a
+browser-capable environment — disproportionate complexity for an integration that is straightforward and unlikely
+to break independently of the rest of the application. The manual post-deploy check provides sufficient coverage
+for this surface.
+
+### 8. Auto-rollback in both test and prod environments
+
+**Decision:** On E2E test failure, the test Cloud Run environment is rolled back to the previous revision. On prod
+deploy failure, prod is rolled back. Both environments revert.
+
+**Why:** Leaving the test environment in a failed state means the next pipeline run starts from a broken baseline,
+which can mask regressions or produce misleading failure signals. Cloud Run revision rollback is a single gcloud
+command with no downtime risk. The cost of reverting test is zero; the benefit is a reliable baseline for all
+subsequent runs.
+
+### 9. GitHub Deployments API for mobile push notifications
+
+**Decision:** Cloud Build posts deployment status events to the GitHub Deployments API after each deploy step.
+GitHub Mobile surfaces these as push notifications natively.
+
+**Why:** The GitHub Deployments API is a first-party integration that triggers GitHub Mobile notifications without
+any third-party service (Slack, PagerDuty, etc.). Cloud Build can POST to the API using a stored `GITHUB_TOKEN`
+secret from Secret Manager. No additional tooling is required.
+
+### 10. Dedicated GCS test bucket in the existing GCP project
+
+**Decision:** A separate GCS bucket (`dungeon-mapster-test`) is used for integration and E2E tests. A separate GCP
+project is not created.
+
+**Why:** A separate bucket provides sufficient isolation to prevent test data from surfacing in production without
+the overhead of managing a second GCP project, IAM structure, or billing account.
+
+## Consequences
+
+- The `ci.yml` GitHub Actions workflow must be updated to enforce the PR gate and not independently trigger
+  deployment (Cloud Build owns the full post-merge pipeline)
+- A `cloudbuild.yaml` must be written encoding: build → integration tests → deploy test → E2E → deploy prod →
+  rollback logic → GitHub status reporting
+- A `test` Spring profile must be added (`application-test.properties`) for Testcontainers configuration
+- Backend `pom.xml` must add Testcontainers dependencies (test scope only)
+- Frontend `package.json` must add `@testing-library/angular`, `@playwright/test`, Husky, and lint-staged
+- `GITHUB_TOKEN` and `JWT_SECRET` must be added to Cloud Build via Secret Manager
+- The GCS test bucket `dungeon-mapster-test` must be created and the Cloud Build service account granted
+  `roles/storage.objectAdmin` on it
+- The test Cloud Run service `dungeon-mapster-test` must be provisioned
+- Cloud Build service account requires: `roles/run.admin`, `roles/artifactregistry.writer`,
+  `roles/secretmanager.secretAccessor`, `roles/storage.objectAdmin`, `roles/iam.serviceAccountUser`
+- Cloud Build trigger must be updated from release-tag to `main` branch push
+- Semantic version release tags are no longer used; any documentation or tooling referencing them must be updated
+- `tech-stack.md` must be updated to reflect the new CI/CD trigger model and added tools
+- Google OAuth is not integration-tested in CI; a manual check after each successful prod deployment is required

--- a/features/37 - ci-cd pipeline/spec.md
+++ b/features/37 - ci-cd pipeline/spec.md
@@ -1,0 +1,234 @@
+# CI/CD Pipeline
+
+## Status
+
+Planning
+
+## Purpose
+
+Establish a fully automated CI/CD pipeline that builds, tests, and deploys the application without any manual steps.
+This includes a complete test suite (unit, integration, and E2E), automatic deployment to test and production
+environments, automatic rollback on failure, and push notifications to GitHub Mobile on deployment failure.
+
+The pipeline replaces the current partially-automated setup (GitHub Actions lint/build + manually-tagged Cloud Build
+triggers) with a fully event-driven flow triggered solely by merges to `main`.
+
+## Pipeline Overview
+
+```
+PR opened
+└── GitHub Actions (PR gate — must pass before merge is allowed)
+    ├── Backend: JUnit 5 unit tests
+    ├── Frontend: Vitest unit + component tests
+    └── Frontend: ESLint
+
+Merge to main
+└── Cloud Build
+    ├── Build Docker image (tagged with kebab-case CalVer + short SHA, e.g. 2026-03-15-a3f2c91)
+    ├── Push image to Artifact Registry
+    ├── Integration tests (Testcontainers — ephemeral PostgreSQL + real GCS test bucket)
+    ├── Deploy image to test Cloud Run
+    ├── E2E tests (Playwright against live test Cloud Run URL)
+    │   ├── Single-user map editor flows
+    │   ├── Multi-user WebSocket (3 concurrent Playwright browser contexts)
+    │   └── Image upload with production-representative file sizes
+    │        ↓ pass → deploy same image to prod Cloud Run
+    │        ↓ fail → rollback test Cloud Run + report failure, halt prod deploy
+
+Deployment failure (test or prod)
+└── GitHub Deployments API status update → GitHub Mobile push notification
+```
+
+## Versioning
+
+Each Docker image tag uses kebab-case combining the build date and the short git SHA:
+
+```
+2026-03-15-a3f2c91
+```
+
+- Built automatically by Cloud Build from `$(date +%Y-%m-%d)` and `$SHORT_SHA`
+- No manual release tags required — every merge to `main` produces a uniquely named, traceable image
+- Cloud Run revisions are named to match the image tag for traceability
+
+## Test Strategy
+
+### Unit Tests (GitHub Actions — PR Gate)
+
+Run on every PR. Fast, no I/O, no infrastructure.
+
+**Backend (JUnit 5 + Mockito):**
+- Service layer logic
+- JWT utility methods
+- Model validation
+- WebSocket message routing logic (mocked session registry)
+
+**Frontend (Vitest + @testing-library/angular):**
+- Component rendering and interaction
+- Angular services (mocked HTTP)
+- WebSocket service state machine (connect / reconnect / disconnect)
+- Presence indicator rendering
+
+### Integration Tests (Cloud Build — post-build)
+
+Run in Cloud Build after the image is built, before deploying to test. Uses Testcontainers to spin up an ephemeral
+PostgreSQL instance per test run. Hibernate creates the full schema from entity definitions on startup using
+`ddl-auto=create-drop`. The container is destroyed after the test run, so no cleanup is required.
+
+**Schema compatibility note:** Hibernate's `create-drop` will surface any foreign key constraint ordering issues as
+a SQL error on first run. This is a quick fix (usually adjusting entity relationship annotations) and requires no
+migration tooling. There is no Flyway or Liquibase involvement in this pipeline — Hibernate manages all schema
+changes automatically from Java entity definitions. If a future schema change requires a destructive migration
+(rename/drop a column with existing data), that will be handled as a separate one-off ticket.
+
+**Backend (Spring Boot Test + Testcontainers):**
+- REST endpoint contracts (MockMvc / WebTestClient)
+- Authentication and JWT validation flows
+- Google OAuth token exchange (mocked — no real token exchange in CI)
+- WebSocket handshake validation (JWT, mapId param)
+- GCS image upload/download (real GCS test bucket in the same GCP project)
+- Session registry lifecycle (connect, heartbeat, disconnect, cleanup)
+- Map cache write-through consistency
+
+**Why Testcontainers over a persistent test Cloud SQL instance:**
+- Each test run starts from a clean schema — no test data accumulates or corrupts across runs
+- A failed mid-run test cannot leave the DB in a state that breaks subsequent tests
+- Spring Boot 3.1+ `@ServiceConnection` integrates Testcontainers with zero boilerplate
+- Eliminates ongoing Cloud SQL cost for a test instance
+
+### E2E Tests (Playwright — against live test Cloud Run)
+
+Run in Cloud Build after deploying to test. Tests execute against the fully deployed application including the
+production Docker image, Cloud SQL, and GCS.
+
+**Single-user flows:**
+- User authentication (Google OAuth flow)
+- Map creation wizard
+- Map editor: cell selection, variable editing, save/load
+- Image upload to GCS and rendering in editor
+
+**Multi-user WebSocket (3 concurrent browser contexts):**
+- User count is a Playwright config variable (`WS_USER_COUNT`, default: `3`)
+- User A and User B edit the same cell simultaneously — last-write-wins verified
+- User A selects a cell — User B and User C see the presence indicator
+- User A focuses a field — User B and User C see the field highlight
+- User C disconnects — User A and User B see presence list updated
+- User C reconnects — full state resync verified
+
+**Image upload with realistic file sizes:**
+- Upload a representative large map image (production-scale)
+- Verify GCS storage and retrieval within acceptable latency
+
+### Pre-commit Hooks (Developer Machine)
+
+Husky + lint-staged, configured in `frontend/package.json`:
+- ESLint on staged frontend files
+- No test execution on commit — unit tests run in CI
+
+## Deployment
+
+### Environments
+
+| Environment | Cloud Run Service      | Trigger                              |
+|-------------|------------------------|--------------------------------------|
+| test        | `dungeon-mapster-test` | Every merge to `main`                |
+| prod        | `dungeon-mapster-prod` | E2E tests pass against test env      |
+
+### Auto-Rollback
+
+On E2E test failure after deploying to test:
+- Revert test Cloud Run to the previous revision via `gcloud run services update-traffic`
+- Halt the pipeline — prod deploy does not proceed
+
+On prod deploy failure (container startup failure, health check failure):
+- Revert prod Cloud Run to the previous revision
+- Report failure via GitHub Deployments API
+
+Auto-rollback applies to both test and prod. Keeping the test environment stable ensures subsequent pipeline runs
+have a reliable baseline to deploy against.
+
+The previous revision tag is retrieved before each deploy step and stored as a Cloud Build substitution variable
+for use in rollback commands.
+
+### GitHub Mobile Notifications (Stretch Goal)
+
+Cloud Build reports deployment status to GitHub via the GitHub Deployments API. GitHub natively surfaces deployment
+failures as push notifications in the GitHub Mobile app — no third-party service required.
+
+Cloud Build posts a `failure` deployment status when:
+- Integration tests fail
+- E2E tests fail (after test rollback)
+- Prod deploy or health check fails (after prod rollback)
+
+A `success` status is posted after prod deploy completes successfully.
+
+## Pre-Implementation Setup (One-Time Manual Steps)
+
+The following must be completed before the pipeline can run. These are infrastructure provisioning steps, not part
+of the implementation PR.
+
+1. **Create test Cloud Run service** — `dungeon-mapster-test` (separate from prod)
+2. **Create GCS test bucket** — `dungeon-mapster-test` (isolated from production bucket)
+3. **Update Cloud Build trigger** — change from release-tag trigger to `main` branch push trigger
+4. **Grant Cloud Build service account permissions** (see below)
+5. **Add secrets to Secret Manager:**
+   - `GITHUB_TOKEN` — personal access token with `repo` scope (for Deployments API)
+   - `JWT_SECRET` — same value as prod, used in integration tests
+   - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — used only if OAuth mock requires them; otherwise omit
+
+### Cloud Build Service Account Permissions
+
+The Cloud Build service account (`[PROJECT_NUMBER]@cloudbuild.gserviceaccount.com`) requires:
+
+| Role | Purpose |
+|------|---------|
+| `roles/run.admin` | Deploy to Cloud Run; update traffic for rollback |
+| `roles/artifactregistry.writer` | Push Docker images |
+| `roles/secretmanager.secretAccessor` | Read secrets from Secret Manager |
+| `roles/storage.objectAdmin` | Read/write to GCS test bucket |
+| `roles/iam.serviceAccountUser` | Act as the Cloud Run service account during deploy |
+
+The Cloud Run service account (the identity the running service uses) already has the necessary Cloud SQL and GCS
+production bucket access. No changes needed there.
+
+## New Dependencies
+
+### Backend
+
+| Dependency                   | Scope | Purpose                                              |
+|------------------------------|-------|------------------------------------------------------|
+| `spring-boot-starter-test`   | test  | JUnit 5, Mockito, MockMvc (likely on classpath already) |
+| `testcontainers-bom`         | test  | BOM for Testcontainers version alignment             |
+| `testcontainers-postgresql`  | test  | Ephemeral PostgreSQL for integration tests           |
+| `spring-boot-testcontainers` | test  | `@ServiceConnection` auto-wiring                     |
+
+### Frontend
+
+| Dependency                  | Scope         | Purpose                                        |
+|-----------------------------|---------------|------------------------------------------------|
+| `@testing-library/angular`  | devDependency | Component testing utilities for Vitest         |
+| `@playwright/test`          | devDependency | E2E and WebSocket multi-user tests             |
+| `husky`                     | devDependency | Pre-commit hook runner                         |
+| `lint-staged`               | devDependency | Run ESLint only on staged files                |
+
+## Environment Configuration
+
+### Spring Profile for Integration Tests
+
+A new Spring profile `test` with:
+- `ddl-auto=create-drop` (Testcontainers manages container lifecycle)
+- GCS bucket pointing to `dungeon-mapster-test`
+- Logging at `WARN` level to reduce CI output noise
+- Google OAuth mocked — no real token exchange
+
+### Cloud Build Substitution Variables
+
+| Variable         | Value                              |
+|------------------|------------------------------------|
+| `_IMAGE_TAG`     | `$(date +%Y-%m-%d)-$SHORT_SHA`     |
+| `_PREV_REVISION` | Retrieved before each deploy step  |
+| `_REGION`        | Cloud Run region (e.g. `us-central1`) |
+
+## Open Questions
+
+None — all design decisions finalized.

--- a/tech-stack.md
+++ b/tech-stack.md
@@ -32,10 +32,17 @@
 
 ## CI/CD
 
-- **GitHub Actions:** `.github/workflows/ci.yml`
-    - Backend: Maven build + tests
-    - Frontend: npm install, lint, build
-- **Cloud Build:** Builds Docker image, pushes to Artifact Registry, deploys to Cloud Run
+- **GitHub Actions:** `.github/workflows/ci.yml` — PR gate only
+    - Backend: JUnit 5 unit tests
+    - Frontend: Vitest unit + component tests, ESLint
+- **Cloud Build:** Triggered on every merge to `main` (no manual release tags)
+    - Builds Docker image tagged `YYYY-MM-DD-{short-sha}` (e.g. `2026-03-15-a3f2c91`)
+    - Runs integration tests (Testcontainers)
+    - Deploys to test Cloud Run, runs Playwright E2E tests
+    - Deploys to prod Cloud Run on E2E pass; auto-rollback on failure
+- **Playwright:** E2E tests including multi-user WebSocket simulation (3 concurrent browser contexts)
+- **Testcontainers:** Ephemeral PostgreSQL for integration tests
+- **Husky + lint-staged:** Pre-commit ESLint on staged frontend files
 
 ## Local Development
 


### PR DESCRIPTION
## Summary

- Adds `features/37 - ci-cd pipeline/spec.md` with full pipeline design: hybrid GitHub Actions (PR gate) + Cloud Build (post-merge), Testcontainers, Playwright E2E with 3-user WebSocket simulation, auto-rollback, CalVer+SHA versioning, and GitHub Mobile notifications
- Adds `features/37 - ci-cd pipeline/adr.md` documenting all architectural decisions and alternatives considered
- Updates `tech-stack.md` to reflect new CI/CD trigger model and added tools

Relates to https://github.com/LemonHound/dungeon-mapster/issues/37 (do not close on merge)

## Test plan

- [ ] Review spec and ADR for accuracy and completeness
- [ ] Confirm pre-implementation setup steps are actionable before opening an implementation conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)