### PR TITLE
fix: explicitly set test DB URL in deploy-test step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -86,6 +86,7 @@ steps:
           --platform=managed \
           --image="$$IMAGE" \
           --region=${_DEPLOY_REGION} \
+          --update-env-vars="SPRING_DATASOURCE_URL=jdbc:postgresql:///dungeonmapster_test?cloudSqlInstance=$_AR_PROJECT_ID:$_DEPLOY_REGION:dungeonmapster-db&socketFactory=com.google.cloud.sql.postgres.SocketFactory,SPRING_PROFILES_ACTIVE=prod" \
           --quiet
 
   # Create GitHub deployment record (returns ID used for all subsequent status updates)


### PR DESCRIPTION
## Summary
- `deploy-test` step now explicitly passes `SPRING_DATASOURCE_URL` pointing to `dungeonmapster_test` via `--update-env-vars`, ensuring Hibernate always creates the schema in the correct test database regardless of the service's existing configuration.

## Test plan
- Trigger Cloud Build — verify `dungeonmapster_test` tables are created on startup and E2E tests reach the auth failure stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)