### PR TITLE
Add HikariCP debug logging to test-cloud profile

### DIFF
--- a/backend/src/main/resources/application-test-cloud.properties
+++ b/backend/src/main/resources/application-test-cloud.properties
@@ -1,1 +1,2 @@
 spring.datasource.url=jdbc:postgresql:///dungeonmapster_test?cloudSqlInstance=${CLOUD_SQL_INSTANCE}&socketFactory=com.google.cloud.sql.postgres.SocketFactory
+logging.level.com.zaxxer.hikari=DEBUG


### PR DESCRIPTION
## Summary
- Adds `logging.level.com.zaxxer.hikari=DEBUG` to `application-test-cloud.properties`
- Diagnostic only: confirms whether the profile loads and which JDBC URL HikariPool connects to
- Will be removed once the datasource issue is resolved

## Test plan
- [ ] Merge and trigger Cloud Build
- [ ] Check Cloud Run test service logs for HikariCP DEBUG output showing the JDBC URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)