### PR TITLE
fix: generate fresh E2E auth token per build via test-only endpoint

### DIFF
--- a/backend/src/main/java/org/dungeonmaps/config/SecurityConfig.java
+++ b/backend/src/main/java/org/dungeonmaps/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/api/test/token").permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().permitAll())
                 .oauth2Login(oauth2 -> oauth2

--- a/backend/src/main/java/org/dungeonmaps/controller/TestTokenController.java
+++ b/backend/src/main/java/org/dungeonmaps/controller/TestTokenController.java
@@ -1,0 +1,40 @@
+package org.dungeonmaps.controller;
+
+import org.dungeonmaps.model.User;
+import org.dungeonmaps.repository.UserRepository;
+import org.dungeonmaps.security.JwtTokenProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/test")
+@ConditionalOnProperty(name = "app.e2e-enabled", havingValue = "true")
+public class TestTokenController {
+
+    private final JwtTokenProvider tokenProvider;
+    private final UserRepository userRepository;
+
+    public TestTokenController(JwtTokenProvider tokenProvider, UserRepository userRepository) {
+        this.tokenProvider = tokenProvider;
+        this.userRepository = userRepository;
+    }
+
+    @PostMapping("/token")
+    public ResponseEntity<Map<String, String>> getTestToken() {
+        User user = userRepository.findByEmail("e2e@dungeon-mapster.internal")
+                .orElseGet(() -> {
+                    User u = new User();
+                    u.setEmail("e2e@dungeon-mapster.internal");
+                    u.setName("E2E Test User");
+                    u.setGoogleId("e2e-test-google-id");
+                    return userRepository.save(u);
+                });
+        String token = tokenProvider.generateToken(user.getId(), user.getEmail());
+        return ResponseEntity.ok(Map.of("token", token));
+    }
+}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -86,7 +86,7 @@ steps:
           --platform=managed \
           --image="$$IMAGE" \
           --region=${_DEPLOY_REGION} \
-          --update-env-vars="DB_NAME=dungeonmapster_test" \
+          --update-env-vars="DB_NAME=dungeonmapster_test,APP_E2E_ENABLED=true" \
           --quiet
 
         gcloud run services update-traffic ${_TEST_SERVICE} \
@@ -114,7 +114,6 @@ steps:
     id: e2e-tests
     waitFor: [github-deployment-create]
     entrypoint: bash
-    secretEnv: [TEST_AUTH_TOKEN]
     args:
       - -c
       - |
@@ -122,8 +121,15 @@ steps:
         npm ci --prefer-offline
         npx playwright install chromium --with-deps
 
+        for i in $(seq 1 12); do
+          TOKEN_RESP=$(curl -sf -X POST ${_TEST_URL}/api/test/token 2>/dev/null) && break
+          echo "Waiting for test service... attempt $i"
+          sleep 10
+        done
+        FRESH_TOKEN=$(echo "$$TOKEN_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['token'])")
+
         BASE_URL=${_TEST_URL} \
-        TEST_AUTH_TOKEN=$$TEST_AUTH_TOKEN \
+        TEST_AUTH_TOKEN="$$FRESH_TOKEN" \
         WS_USER_COUNT=3 \
         npx playwright test \
         || echo "failed" > /workspace/e2e-failed
@@ -190,8 +196,6 @@ availableSecrets:
       env: GITHUB_TOKEN
     - versionName: projects/$_AR_PROJECT_ID/secrets/JWT_SECRET/versions/latest
       env: JWT_SECRET
-    - versionName: projects/$_AR_PROJECT_ID/secrets/TEST_AUTH_TOKEN/versions/latest
-      env: TEST_AUTH_TOKEN
 
 options:
   substitutionOption: ALLOW_LOOSE


### PR DESCRIPTION
## Summary
- Static `TEST_AUTH_TOKEN` JWT expired after 24 hours, causing `beforeAll` API calls to return Google OAuth2 HTML (200 OK) instead of JSON, failing all 9 E2E tests
- Adds `TestTokenController` (gated by `APP_E2E_ENABLED=true`) that creates/finds an e2e test user and returns a fresh JWT per build
- CI now fetches a fresh token via retry loop (also serves as a readiness probe for the newly deployed revision) instead of using the stale static secret
- Also fixes missing `#!/bin/sh` shebang in `.husky/pre-commit` that caused "Exec format error" in worktrees

## Test plan
- [ ] Push to main triggers CI build
- [ ] `deploy-test` step sets `APP_E2E_ENABLED=true` on the test Cloud Run service
- [ ] `e2e-tests` step successfully fetches a fresh token from `/api/test/token`
- [ ] All 9 Playwright tests pass
- [ ] `post-e2e` deploys to production and posts a success status

🤖 Generated with [Claude Code](https://claude.com/claude-code)