### PR TITLE
fix: update prod URL to dungeonmapster.com custom domain

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -5,4 +5,4 @@ spring.datasource.hikari.maximum-pool-size=3
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 server.forward-headers-strategy=native
-app.frontend-url=https://dungeonmapster-675207457500.us-central1.run.app
+app.frontend-url=https://dungeonmapster.com

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ substitutions:
   _TEST_SERVICE: dungeon-mapster-test
   _PROD_SERVICE: dungeonmapster
   _TEST_URL: https://dungeon-mapster-test-675207457500.us-central1.run.app
-  _PROD_URL: https://dungeonmapster-675207457500.us-central1.run.app
+  _PROD_URL: https://dungeonmapster.com
 
 steps:
   # Compute image tag: YYYY-MM-DD-{short-sha}


### PR DESCRIPTION
## Summary
- Update `_PROD_URL` in `cloudbuild.yaml` to `https://dungeonmapster.com`
- Update `app.frontend-url` in `application-prod.properties` to `https://dungeonmapster.com` (CORS + OAuth redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)